### PR TITLE
Call for Participation 

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,7 +11,9 @@ compile_sass = true
  highlight_code = true
 
 # Whether to build a search index to be used later on by a JavaScript library
+[search]
 build_search_index = true
+
 
 title = "Rust Edu"
 description = ""

--- a/config.toml
+++ b/config.toml
@@ -7,14 +7,21 @@ compile_sass = true
 
 # Whether to do syntax highlighting
 # Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
- [markdown]
-highlighting = true
+[markdown]
 render_emoji = true
 smart_punctuation = true
+
+# [markdown.highlighting]
+
+
 
 # Whether to build a search index to be used later on by a JavaScript library
 [search]
 build_search_index = true
+
+[link_checker]
+internal_level = "error"
+external_level = "warn"
 
 
 title = "Rust Edu"

--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,9 @@ compile_sass = true
 # Whether to do syntax highlighting
 # Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
  [markdown]
- highlight_code = true
+highlighting = true
+render_emoji = true
+smart_punctuation = true
 
 # Whether to build a search index to be used later on by a JavaScript library
 [search]

--- a/content/news/call_for_participation.md
+++ b/content/news/call_for_participation.md
@@ -29,14 +29,13 @@ In addition, we are forming a **Rust-Edu Organizing Committee** a group of commi
 
 If this sounds like something you do like to be part of, we invite you to complete the form linked below.
 
-Fill it out, and we’ll be in touch soon.
-
-👉 [Apply here](https://forms.gle/2TXRRBhTLm6HCJVq8)  
+Fill it out, and we’ll be in touch soon.👉 [Apply here](https://forms.gle/2TXRRBhTLm6HCJVq8)  
 
 ## Looking Ahead
 
 We’re optimistic about what lies ahead.
 
 With the right people, shared vision, and consistent effort, we believe Rust-Edu can play a meaningful role in shaping how Rust is taught and adopted in universities around the world.
+
 
 Hopefully, to building something impactful together join our [**zulip channel**](https://rust-edu.zulip.cs.pdx.edu/#narrow/channel/576-Rust-Edu-CFP/topic/channel.20events/with/87780) to stay in touch.

--- a/content/news/call_for_participation.md
+++ b/content/news/call_for_participation.md
@@ -5,3 +5,38 @@ date = 2026-03-31
 [extra]
 author = "Mordecai Etukudo"
 +++
+
+
+# A New Chapter for Rust-Edu
+
+It’s a new year and with it comes a fresh start for [**Rust-Edu**]((https://rust-edu.org)).
+
+Founded several years ago, Rust-Edu was created with a clear mission: to promote Rust education globally, with a strong focus on bringing Rust into academia. Thanks to an early and generous contribution from FutureWei, the initiative was able to take its first steps toward that vision.
+
+Since then, Rust-Edu has supported the development of educational content and curricula, collaborated with educators and communities, and helped spread awareness of Rust within academic circles. Along the way, we’ve also contributed directly to teaching and learning efforts within the ecosystem.
+
+However, like many grassroots initiatives, sustaining momentum hasn’t been easy. Building and maintaining a consistent, long-term team has proven challenging especially as a largely solo effort. But things are changing.
+
+Recently, I’ve been working closely with **Mordecai Etukudo of Rust Africa**, whose energy, organizational experience, and commitment to community growth have brought new life to our efforts. Together, we’re focused on rebuilding Rust-Edu into a more structured, collaborative, and impactful initiative.
+
+## Where You Come In
+
+This next phase of Rust-Edu is not something we want to build alone we want to build it with you.
+
+We’re looking for individuals who are passionate about Rust education, particularly in academic environments, and who are excited to contribute their time, ideas, and experience. Whether you're an educator, developer, student, or community builder, there’s a place for you here.
+
+In addition, we are forming a **Rust-Edu Organizing Committee** a group of committed contributors who will help guide and lead our upcoming initiatives. This will involve regular collaboration, planning, and execution of programs that push Rust education forward.
+
+If this sounds like something you do like to be part of, we invite you to complete the form linked below.
+
+Fill it out, and we’ll be in touch soon.
+
+👉 [Apply here](https://forms.gle/2TXRRBhTLm6HCJVq8)  
+
+## Looking Ahead
+
+We’re optimistic about what lies ahead.
+
+With the right people, shared vision, and consistent effort, we believe Rust-Edu can play a meaningful role in shaping how Rust is taught and adopted in universities around the world.
+
+Hopefully, to building something impactful together join our [**zulip channel**](https://rust-edu.zulip.cs.pdx.edu/#narrow/channel/576-Rust-Edu-CFP/topic/channel.20events/with/87780) to stay in touch.

--- a/content/news/call_for_participation.md
+++ b/content/news/call_for_participation.md
@@ -1,0 +1,7 @@
++++
+title = "Announcing the 2026 Rust-Edu Refresh and CFP"
+date = 2026-03-31
+
+[extra]
+author = "Mordecai Etukudo"
++++


### PR DESCRIPTION
This pull request adds a new announcement post for the 2026 Rust-Edu Refresh and Call for Participation. The post outlines the recent revitalization of Rust-Edu, introduces new leadership collaboration, and invites community members to join the organizing committee and contribute to upcoming initiatives.

New content addition:

* Added a new Markdown file `call_for_participation.md` in the `content/news` directory, announcing the 2026 Rust-Edu Refresh, summarizing the initiative's history, new leadership, and issuing a call for participation and committee applications.